### PR TITLE
Feat/1 : WAS-DB(NoSQL) 사이 트래픽 분산 시스템 구축

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/application/src/main/java/researchProject/sessionServer/domain/readRequest/manager/SessionValkeyReadManager.java
+++ b/application/src/main/java/researchProject/sessionServer/domain/readRequest/manager/SessionValkeyReadManager.java
@@ -2,21 +2,85 @@ package researchProject.sessionServer.domain.readRequest.manager;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 @Component
-@RequiredArgsConstructor
+// @RequiredArgsConstructor
 public class SessionValkeyReadManager {
 
-    @Qualifier("sessionValkeyTemplate")
-    private final RedisTemplate<String, String> sessionValkeyTemplate;
+    // Read1 인스턴스 Host
+    @Value("${session.read1.host}")
+    private String host1;
+
+    // Read1 인스턴스 Port
+    @Value("${session.read1.port}")
+    private int port1;
+
+    // Read2 인스턴스 Host
+    @Value("${session.read2.host}")
+    private String host2;
+
+    // Read2 인스턴스 Port
+    @Value("${session.read2.port}")
+    private int port2;
+
+    private final AtomicInteger rrCounter = new AtomicInteger(0);
+
+    // 호출마다 다른 replica 선택
+    private RedisTemplate<String, String> nextTemplate() {
+        int index = rrCounter.getAndUpdate(i -> (i + 1) % 2);
+
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        if (index == 0) {
+            config.setHostName(host1);
+            config.setPort(port1);
+        } else {
+            config.setHostName(host2);
+            config.setPort(port2);
+        }
+
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.afterPropertiesSet();
+        return template;
+    }
 
     // 세션 서버에서 값 조회
     public String getValue(String key) {
-        ValueOperations<String, String> ops = sessionValkeyTemplate.opsForValue();
+        RedisTemplate<String, String> template = nextTemplate();
+        ValueOperations<String, String> ops = template.opsForValue();
         return ops.get(key);
     }
+
+    // ======================= deprecated =========================
+
+    /**
+     * sessionReadTemplate 라운드 로빈 방식은 Bean 생성 시점에만 한 번 선택되는데,
+     * 호출마다 다른 replica를 타야 한다면 Manager 쪽에서 ConnectionFactory를 직접 돌려주는 방식으로 바꿔야 합니다.
+     * 현재 구조는 "애플리케이션 구동 시 한 번 선택된 replica만 계속 사용"
+     *
+     */
+//    private final RedisTemplate<String, String> sessionValkeyTemplate;
+//
+//    public SessionValkeyReadManager(
+//            @Qualifier("sessionReadTemplate") RedisTemplate<String, String> sessionValkeyTemplate) {
+//        this.sessionValkeyTemplate = sessionValkeyTemplate;
+//    }
+//
+//    // 세션 서버에서 값 조회
+//    public String getValue(String key) {
+//        ValueOperations<String, String> ops = sessionValkeyTemplate.opsForValue();
+//        return ops.get(key);
+//    }
 
 }

--- a/application/src/main/java/researchProject/sessionServer/domain/writeRequest/manager/SessionValkeyWriteManager.java
+++ b/application/src/main/java/researchProject/sessionServer/domain/writeRequest/manager/SessionValkeyWriteManager.java
@@ -9,11 +9,15 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.TimeUnit;
 
 @Component
-@RequiredArgsConstructor
+// @RequiredArgsConstructor
 public class SessionValkeyWriteManager {
 
-    @Qualifier("sessionValkeyTemplate")
     private final RedisTemplate<String, String> sessionValkeyTemplate;
+
+    public SessionValkeyWriteManager(
+            @Qualifier("sessionWriteTemplate") RedisTemplate<String, String> sessionValkeyTemplate) {
+        this.sessionValkeyTemplate = sessionValkeyTemplate;
+    }
 
     // 세션 서버에 값 저장
     public void setValue(String key, String value, long ttlMinutes) {

--- a/application/src/main/java/researchProject/sessionServer/global/sessionConnector/ValkeyConfig.java
+++ b/application/src/main/java/researchProject/sessionServer/global/sessionConnector/ValkeyConfig.java
@@ -4,51 +4,126 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 @Configuration
 public class ValkeyConfig {
 
-    // Valkey Session Redis 설정
-    @Value("${spring.data.valkey.session.host}")
-    private String sessionValkeyHost;
+    // Write 인스턴스 Host
+    @Value("${session.write.host}")
+    private String sessionWriteHost;
 
-    @Value("${spring.data.valkey.session.port}")
-    private int sessionValkeyPort;
+    // Write 인스턴스 Port
+    @Value("${session.write.port}")
+    private int sessionWritePort;
 
-    // ======================= Redis Basic Config =========================
+    // Read1 인스턴스 Host
+    @Value("${session.read1.host}")
+    private String sessionRead1Host;
 
-    // 기본 이름의 RedisTemplate (Valkey용)
-    @Bean(name = "valkeyTemplate")
-    public RedisTemplate<String, String> valkeyTemplate(
-            @Qualifier("sessionRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
-        return sessionValkeyTemplate(connectionFactory); // 재사용
+    // Read1 인스턴스 Port
+    @Value("${session.read1.port}")
+    private int sessionRead1Port;
+
+    // Read2 인스턴스 Host
+    @Value("${session.read2.host}")
+    private String sessionRead2Host;
+
+    // Read2 인스턴스 Port
+    @Value("${session.read2.port}")
+    private int sessionRead2Port;
+
+    // ======================= Write =========================
+    @Bean(name = "sessionWriteTemplate")
+    public RedisTemplate<String, String> sessionWriteTemplate(
+            @Qualifier("sessionPrimaryConnectionFactory") RedisConnectionFactory connectionFactory) {
+        return buildTemplate(connectionFactory);
     }
 
-    // ======================= Session Redis =========================
-
-    // Session Redis Connection Factory
-    @Bean(name = "sessionRedisConnectionFactory")
-    public RedisConnectionFactory sessionRedisConnectionFactory() {
+    @Bean(name = "sessionPrimaryConnectionFactory")
+    public RedisConnectionFactory sessionPrimaryConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(sessionValkeyHost);
-        config.setPort(sessionValkeyPort);
+        config.setHostName(sessionWriteHost);
+        config.setPort(sessionWritePort);
         return new LettuceConnectionFactory(config);
     }
 
-    // Session RedisTemplate (데이터 저장용)
-    @Bean(name = "sessionValkeyTemplate")
-    public RedisTemplate<String, String> sessionValkeyTemplate(
-            @Qualifier("sessionRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
+    // ======================= Read (Round Robin) =========================
+    private final AtomicInteger rrCounter = new AtomicInteger(0);
+
+    @Bean(name = "sessionReadTemplate")
+    public RedisTemplate<String, String> sessionReadTemplate() {
+        return buildTemplate(nextReplicaConnectionFactory());
+    }
+
+    private RedisConnectionFactory nextReplicaConnectionFactory() {
+        int index = rrCounter.getAndUpdate(i -> (i + 1) % 2);
+
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        if (index == 0) {
+            config.setHostName(sessionRead1Host);
+            config.setPort(sessionRead1Port);
+        } else {
+            config.setHostName(sessionRead2Host);
+            config.setPort(sessionRead2Port);
+        }
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+        return factory;
+    }
+
+    // ======================= 공용 템플릿 빌더 =========================
+
+    /* 증복 제거용 Helper 메서드 */
+    // RedisTemplate 생성 시 중복되는 초기화 로직을 공용 메서드로 뺀 것.
+    // sessionWriteTemplate / sessionReadTemplate 모두 동일한 방식으로 일관성 있게 초기화
+    private RedisTemplate<String, String> buildTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
-        template.afterPropertiesSet(); // 필수
+        template.afterPropertiesSet();
         return template;
     }
+
+    // ======================= Deprecated =========================
+
+    // ======================= Redis Basic Config =========================
+
+//    // 기본 이름의 RedisTemplate (Valkey용)
+//    @Bean(name = "valkeyTemplate")
+//    public RedisTemplate<String, String> valkeyTemplate(
+//            @Qualifier("sessionRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
+//        return sessionValkeyTemplate(connectionFactory); // 재사용
+//    }
+
+    // ======================= Session Redis  =========================
+
+//    // Session Redis Connection Factory
+//    @Bean(name = "sessionRedisConnectionFactory")
+//    public RedisConnectionFactory sessionRedisConnectionFactory() {
+//        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+//        config.setHostName(sessionValkeyHost);
+//        config.setPort(sessionValkeyPort);
+//        return new LettuceConnectionFactory(config);
+//    }
+//
+//    // Session RedisTemplate (데이터 저장용)
+//    @Bean(name = "sessionValkeyTemplate")
+//    public RedisTemplate<String, String> sessionValkeyTemplate(
+//            @Qualifier("sessionRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
+//        RedisTemplate<String, String> template = new RedisTemplate<>();
+//        template.setConnectionFactory(connectionFactory);
+//        template.setKeySerializer(new StringRedisSerializer());
+//        template.setValueSerializer(new StringRedisSerializer());
+//        template.afterPropertiesSet(); // 필수
+//        return template;
+//    }
 }

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -2,5 +2,9 @@ spring.application.name=sessionServer
 
 # Redis for session
 # spring.session.store-type=none
-spring.data.valkey.session.host=localhost
-spring.data.valkey.session.port=6379
+session.write.host=localhost
+session.write.port=6379
+session.read1.host=localhost
+session.read1.port=6380
+session.read2.host=localhost
+session.read2.port=6381

--- a/sessionServer/documents/Command.md
+++ b/sessionServer/documents/Command.md
@@ -1,10 +1,13 @@
 ### 1. Terminal 명령어 모음
 
 #### 1-1. 인스턴스 > CLI 환경 입장 
-docker exec -it valkey-primary valkey-cli    
-docker exec -it valkey-replica-1 valkey-cli    
-docker exec -it valkey-replica-2 valkey-cli
+* docker exec -it valkey-primary valkey-cli    
+* docker exec -it valkey-replica-1 valkey-cli    
+* docker exec -it valkey-replica-2 valkey-cli
 
 #### 1-2. 데이터 조회 명령어 
 
 #### 1-3. 데이터 삽입 명령어 
+
+#### 1-4. 실시간 API 호출 모니터링 명령어 
+* monitor

--- a/sessionServer/documents/Command.md
+++ b/sessionServer/documents/Command.md
@@ -1,0 +1,10 @@
+### 1. Terminal 명령어 모음
+
+#### 1-1. 인스턴스 > CLI 환경 입장 
+docker exec -it valkey-primary valkey-cli    
+docker exec -it valkey-replica-1 valkey-cli    
+docker exec -it valkey-replica-2 valkey-cli
+
+#### 1-2. 데이터 조회 명령어 
+
+#### 1-3. 데이터 삽입 명령어 


### PR DESCRIPTION
1. Primary-Replica 복제를 통한 NoSQL 이중화 완료 → 고가용성 확보   
* 문서화 링크 : https://knotty-toast-80a.notion.site/Primary-Replica-NoSQL-26b1979809dd80799325c59bffed9b1e?source=copy_link

2. 대규모 Read 트래픽 대비 Valkey Session Server의 Read-Write 권한 분산       
* 문서화 링크 : https://knotty-toast-80a.notion.site/Read-Valkey-Session-Server-Read-Write-26b1979809dd80058923d891009a2360?source=copy_link

3. Write Traffic → Primary , Read Traffic → Replica로 트래픽을 분기하는 Manager 구현   
4. 트래픽 분산 테스트 완료 
* 문서화 링크 : https://knotty-toast-80a.notion.site/Write-Traffic-Primary-Read-Traffic-Replica-Manager-26b1979809dd80e4a125e24ffb94c37f?source=copy_link



